### PR TITLE
Ignore `composer-runtime-api` package

### DIFF
--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -137,7 +137,7 @@ class Build
             }
 
             if (!isset($packages[$dependencyName])) {
-                if ($dependencyName == $vendorDir . '/composer-plugin-api') {
+                if ($dependencyName == $vendorDir . '/composer-plugin-api' || $dependencyName == $vendorDir . '/composer-runtime-api') {
                     continue;
                 }
                 if($isVendor){


### PR DESCRIPTION
Similarly to the `composer-plugin-api`, `composer-runtime-api` should also be ignored to prevent errors like

```                                                                                                                                                       
  [RuntimeException]                                                                                                                                       
  Requiring non-existent composer-package 'vendor/composer-runtime-api' in 'vendor/ocramius/proxy-manager'. Please ensure it is present in composer.json.  
```